### PR TITLE
keyboard macOS compatibility

### DIFF
--- a/device/src/usb/keyboard_app.hpp
+++ b/device/src/usb/keyboard_app.hpp
@@ -33,7 +33,8 @@ class keyboard_app : public hid::application
 
         // clang-format off
         return descriptor(
-            usage_extended(generic_desktop::KEYBOARD),
+            usage_page<generic_desktop>(),
+            usage(generic_desktop::KEYBOARD),
             collection::application(
                 // 6KRO input keys report
                 keys_input_report_descriptor<KEYS_6KRO_REPORT_ID>(),


### PR DESCRIPTION
This branch changes the 6KRO mode to change the report desciptor altogether, having only a 6KRO report. @mondalaci please give it a try on MacOS, switch it into 6KRO mode **before** connecting to the host.