### PR TITLE
cmake add -Wno-dev flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you're one of the brave few who wants to hack the firmware then read on.
 west init -m git@github.com:UltimateHackingKeyboard/firmware-uhk80.git firmware-uhk80
 cd firmware-uhk80
 west update
+west config --local build.cmake-args -- "-Wno-dev"
 cd uhk/lib
 git submodule init --recursive
 git submodule update --init --recursive

--- a/device/CMakePresets.json
+++ b/device/CMakePresets.json
@@ -16,6 +16,9 @@
                 "BOARD_ROOT": "${sourceParentDir}/",
                 "CONF_FILE": "${sourceDir}/prj.conf",
                 "OVERLAY_CONFIG": "${sourceDir}/prj.conf.overlays/uhk-60-v1-right.prj.conf"
+            },
+            "warnings": {
+                "dev": false
             }
         },
         {
@@ -29,6 +32,9 @@
                 "BOARD_ROOT": "${sourceParentDir}/",
                 "CONF_FILE": "${sourceDir}/prj.conf",
                 "OVERLAY_CONFIG": "${sourceDir}/prj.conf.overlays/uhk-60-v2-right.prj.conf"
+            },
+            "warnings": {
+                "dev": false
             }
         },
         {
@@ -42,6 +48,9 @@
                 "BOARD_ROOT": "${sourceParentDir}/",
                 "mcuboot_OVERLAY_CONFIG": "${sourceDir}/child_image/mcuboot.conf;${sourceDir}/child_image/uhk-80-right.mcuboot.conf",
                 "EXTRA_CONF_FILE": "${sourceDir}/prj.conf.overlays/uhk-80-right.prj.conf"
+            },
+            "warnings": {
+                "dev": false
             }
         },
         {
@@ -55,6 +64,9 @@
                 "BOARD_ROOT": "${sourceParentDir}/",
                 "mcuboot_OVERLAY_CONFIG": "${sourceDir}/child_image/mcuboot.conf;${sourceDir}/child_image/uhk-80-left.mcuboot.conf",
                 "EXTRA_CONF_FILE": "${sourceDir}/prj.conf.overlays/uhk-80-left.prj.conf"
+            },
+            "warnings": {
+                "dev": false
             }
         },
         {
@@ -68,6 +80,9 @@
                 "BOARD_ROOT": "${sourceParentDir}/",
                 "mcuboot_OVERLAY_CONFIG": "${sourceDir}/child_image/mcuboot.conf;${sourceDir}/child_image/uhk-dongle.mcuboot.conf",
                 "EXTRA_CONF_FILE": "${sourceDir}/prj.conf.overlays/uhk-dongle.prj.conf"
+            },
+            "warnings": {
+                "dev": false
             }
         }
     ]


### PR DESCRIPTION
Here is the most probable solution for UltimateHackingKeyboard/firmware#846 according to my current knowledge. No idea if this works, trying to figure out this issue already sent my own laptop to the afterlife, and trying from scratch to solve it again on the Macbook resulted in an environment where I cannot build the application anymore, even uninstalling the whole nRF Connect SDK, toolchain and VSCode itself cannot fix the problem with the west configuration. I will sink a further unreasonable amount of effort just to get the build to work again, so maybe you want to try this out by yourself as well. (These changes themselves aren't the reason I'm in this mess, it's rather because of poor documentation of west config, that I managed to mess up in the process.)