### PR TITLE
Wakeup main thread when config is applied.

### DIFF
--- a/right/src/usb_commands/usb_command_apply_config.c
+++ b/right/src/usb_commands/usb_command_apply_config.c
@@ -13,6 +13,10 @@
 #include "led_manager.h"
 #include "legacy/event_scheduler.h"
 
+#ifdef __ZEPHYR__
+#include "main.h"
+#endif
+
 void updateUsbBuffer(uint8_t usbStatusCode, uint16_t parserOffset, parser_stage_t parserStage)
 {
     SetUsbTxBufferUint8(0, usbStatusCode);
@@ -22,6 +26,9 @@ void updateUsbBuffer(uint8_t usbStatusCode, uint16_t parserOffset, parser_stage_
 
 void UsbCommand_ApplyConfigAsync(void) {
     EventVector_Set(EventVector_ApplyConfig);
+#ifdef __ZEPHYR__
+    k_wakeup(Main_ThreadId);
+#endif
 }
 
 void UsbCommand_ApplyConfig(void)


### PR DESCRIPTION
Minor fix of one of the previous PRs. 

When writing user config, it was not reloaded until next scheduler event woke the main thread...