### PR TITLE
Improve serial no compatibility for Windows.

### DIFF
--- a/right/src/usb_descriptors/usb_descriptor_strings.c
+++ b/right/src/usb_descriptors/usb_descriptor_strings.c
@@ -89,10 +89,10 @@ USB_DESC_STORAGE_TYPE_VAR(uint8_t) UsbSerialString[USB_SERIAL_STRING_DESCRIPTOR_
     'i', 0x00U,
     'a', 0x00U,
     'l', 0x00U,
-    ' ', 0x00U,
-    ' ', 0x00U,
-    ' ', 0x00U,
-    ' ', 0x00U,
+    '0', 0x00U,
+    '0', 0x00U,
+    '0', 0x00U,
+    '0', 0x00U,
 };
 
 const uint32_t UsbStringDescriptorLengths[USB_STRING_DESCRIPTOR_COUNT] = {
@@ -128,10 +128,13 @@ usb_status_t USB_DeviceGetStringDescriptor(
 
 void USB_SetSerialNo(uint32_t serial)
 {
-    char serialString[10];
-    size_t len = sprintf(serialString, "%li", serial);
-    for (size_t i = 0; i < len; i++) {
+#define SERIAL_LEN 10
+    char serialString[SERIAL_LEN];
+    sprintf(serialString, "%li", serial);
+    for (size_t i = 0; i < SERIAL_LEN; i++) {
+        if (serialString[i] < '0' || serialString[i] > '9') {
+            serialString[i] = '0';
+        }
         UsbSerialString[2 * i + 2] = serialString[i];
     }
-    UsbSerialString[0] = 2 * len + 2;
 }


### PR DESCRIPTION
@mondalaci please give a try to this branch.

I have tested UHK60v1 against two windows machines, one Windows 10 and one Windows 11, and in the booted system, everything works fine.

The only trouble I have experienced is that the keyboard didn't work in windows bootloader (I was required to enter a bitlocker security key). I suppose that this is caused by nkro/boot fallback troubles.

Also please note this point:

![2024-09-22-120513_1006x129_scrot](https://github.com/user-attachments/assets/83764591-43be-449f-8d48-46f14d976824)

Closes UltimateHackingKeyboard/firmware#936 