### PR TITLE
Make sure to wake up main thread if current next event is rescheduled.

### DIFF
--- a/right/src/event_scheduler.c
+++ b/right/src/event_scheduler.c
@@ -103,7 +103,7 @@ void EventScheduler_Reschedule(uint32_t at, event_scheduler_event_t evt, const c
     if (nextEvent == evt) {
         scheduleNext();
     }
-    if (at < nextEventAt || !EventVector_IsSet(EventVector_EventScheduler)) {
+    if (at < nextEventAt || !EventVector_IsSet(EventVector_EventScheduler) || nextEvent == evt) {
         nextEventAt = at;
         nextEvent = evt;
         EventVector_Set(EventVector_EventScheduler);


### PR DESCRIPTION
Sorry, I don't have reproduction steps.

But I suspect that if a currently scheduled event (i.e., the first one in the "queue") is rescheduled to a sooner time, the main thread doesn't get woken up.