### PR TITLE
Update functional colors when link is resetted.

### DIFF
--- a/device/src/state_sync.c
+++ b/device/src/state_sync.c
@@ -648,6 +648,7 @@ void StateSync_ResetRightLeftLink(bool bidirectional)
         }
         invalidateProperty(StateSyncPropertyId_ActiveLayer);
         invalidateProperty(StateSyncPropertyId_Backlight);
+        invalidateProperty(StateSyncPropertyId_FunctionalColors);
     }
     if (DEVICE_ID == DeviceId_Uhk80_Left) {
         invalidateProperty(StateSyncPropertyId_Battery);


### PR DESCRIPTION
This is a minor fix, I didn't bother to test it, but I suspect it should be possible to trigger as follows:

- change functional colors and save them
- `kernel reboot cold` left half
- now I suspect default colors are lit up on the left half