### PR TITLE
Fix i2c objects missing in dongle build.

### DIFF
--- a/right/src/i2c.c
+++ b/right/src/i2c.c
@@ -1,5 +1,6 @@
 #include "i2c.h"
 #include "crc16.h"
+#include "stubs.h"
 
 #ifdef __ZEPHYR__
 #include "keyboard/i2c.h"

--- a/right/src/stubs.h
+++ b/right/src/stubs.h
@@ -9,6 +9,13 @@
     #include "attributes.h"
     #include "key_action.h"
 
+
+    #ifdef __ZEPHYR__
+        #include "keyboard/i2c_compatibility.h"
+    #else
+        #include "fsl_i2c.h"
+    #endif
+
 // Macros:
 
 #define ATTRS __attribute__((weak)) __attribute__((unused))
@@ -26,6 +33,7 @@
     ATTRS const rgb_t* PairingScreen_ActionColor(key_action_t* action) { return NULL; };
     ATTRS void Uart_Reenable() {};
     ATTRS void Uart_Enable() {};
+    ATTRS status_t ZephyrI2c_MasterTransferNonBlocking(i2c_master_transfer_t *transfer) { return kStatus_Fail; };
 
 #if DEVICE_HAS_OLED
 #define WIDGET_REFRESH(W) Widget_Refresh(W)


### PR DESCRIPTION
I really don't understand why this issue did not exhibit a long time ago, and I don't understand why #268 should trigger it.

But here is a fix 🤦.