### PR TITLE
Implement lightSleep and deepSleep modes.

### DIFF
--- a/doc-dev/reference-manual.md
+++ b/doc-dev/reference-manual.md
@@ -113,7 +113,7 @@ COMMAND = {startMouse|stopMouse} {move DIRECTION|scroll DIRECTION|accelerate|dec
 COMMAND = setVar <variable name (IDENTIFIER)> <value (PARENTHESSED_EXPRESSION)>
 COMMAND = {pressKey|holdKey|tapKey|releaseKey} SHORTCUT
 COMMAND = tapKeySeq [SHORTCUT]+
-COMMAND = powerMode [toggle] { wake | sleep }
+COMMAND = powerMode [toggle] { wake | lightSleep | sleep | deepSleep }
 COMMAND = set module.MODULEID.navigationMode.LAYERID_BASIC NAVIGATION_MODE
 COMMAND = set module.MODULEID.baseSpeed <non-xcelerated speed, 0-10.0 (FLOAT)>
 COMMAND = set module.MODULEID.speed <xcelerated speed, 0-10.0 (FLOAT)>
@@ -316,9 +316,14 @@ COMMAND = setEmergencyKey KEYID
 - `resetTrackpoint` resets the internal trackpoint board. Can be used to recover the trackpoint from drift conditions. Drifts usually happen if you keep the cursor moving at slow constant speeds, because of the boards's internal adaptive calibration. Since the board's parameters cannot be altered, the only way around is or you to learn not to do the type of movement which triggers them.
 - `i2cBaudRate <baud rate, default 100000(INT)>` sets i2c baud rate. Lowering this value may improve module reliability, while increasing latency.
 - `{|}` Braces allow grouping multiple commands as if they were a single command. Please note that from the point of view of the engine, braces are (almost) regular commands, and have to be followed by newlines like any other command. Therefore idioms like `} else {` are not possible at the moment.
-- `powerMode [toggle] { wake | sleep }`
-  - `sleep` will disable all leds, disables USB output, and puts the device into a low-power mode. If `toggle` is specified and the device is already in the mode, it will wake the device instead.
-  - `wake` will wake up the device from sleep mode.
+- `powerMode [toggle] { wake | lightSleep | sleep | deepSleep }`
+  - `lightSleep` disables all leds. When any key is pressed, the uhk is waked up, and remote wakeup of the host is attempted.
+  - `deepSleep` disables all leds, disables USB output, and (in the future will) put the device into a low-power mode.
+  - `sleep` is a general alias that at the moment points to `deepSleep`.
+  - `wake` wakes up the device from "any" sleep mode (that doesn't disable macro engine and the half link).
+  Further rules:
+    - If a sleep mode is activated while another sleep mode is active, the deeper of them will be activated.
+    - If `toggle` is specified and the device is already in the (exact) sleep mode, it will wake the device instead.
 
 ### Triggering keyboard actions (pressing keys, clicking, etc.):
 

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1410,11 +1410,17 @@ static macro_result_t processPowerModeCommand(parser_context_t* ctx) {
         toggle = true;
     }
 
-    if (ConsumeToken(ctx, "sleep")) {
+    if (ConsumeToken(ctx, "deepSleep") || ConsumeToken(ctx, "sleep")) {
         if (Macros_DryRun) {
             return MacroResult_Finished;
         }
-        PowerMode_ActivateMode(PowerMode_Sleep, toggle);
+        PowerMode_ActivateMode(PowerMode_DeepSleep, toggle);
+    }
+    else if (ConsumeToken(ctx, "lightSleep")) {
+        if (Macros_DryRun) {
+            return MacroResult_Finished;
+        }
+        PowerMode_ActivateMode(PowerMode_LightSleep, toggle);
     }
     else if (ConsumeToken(ctx, "wake")) {
         if (Macros_DryRun) {

--- a/right/src/power_mode.h
+++ b/right/src/power_mode.h
@@ -13,8 +13,9 @@
 
 typedef enum {
     PowerMode_Awake,
-    PowerMode_Sleep,
-    PowerMode_Uhk60Sleep = PowerMode_Sleep,
+    PowerMode_LightSleep,
+    PowerMode_Uhk60Sleep = PowerMode_LightSleep,
+    PowerMode_DeepSleep,
     PowerMode_Count,
 } power_mode_t;
 // Variables:

--- a/right/src/usb_report_updater.c
+++ b/right/src/usb_report_updater.c
@@ -547,8 +547,9 @@ static void updateActionStates() {
                     // as it is pressed
                     actionCache[slotId][keyId].modifierLayerMask = 0;
 
-                    if (CurrentPowerMode >= PowerMode_Sleep) {
+                    if (CurrentPowerMode != PowerMode_Awake && CurrentPowerMode <= PowerMode_LightSleep) {
                         PowerMode_WakeHost();
+                        PowerMode_ActivateMode(PowerMode_Awake, false);
                     }
 
                     if (Postponer_LastKeyLayer != 255 && PostponerCore_IsActive()) {
@@ -731,7 +732,7 @@ void UpdateUsbReports(void)
 
     updateActiveUsbReports();
 
-    if (EventVector_IsSet(EventVector_ReportsChanged) && CurrentPowerMode < PowerMode_Sleep) {
+    if (EventVector_IsSet(EventVector_ReportsChanged) && CurrentPowerMode < PowerMode_DeepSleep) {
         mergeReports();
         sendActiveReports();
     } else {


### PR DESCRIPTION
As discussed.

Computer suspends now invokes lightSleep.

Macro can invoke either of them.

As for testing, you can leave the old `powerMode toggle sleep`, as "sleep" is now an alias for "recommended sleep mode".