### PR TITLE
Fix config host connection parsing on uhk 60

### DIFF
--- a/right/src/config_parser/parse_host_connection.c
+++ b/right/src/config_parser/parse_host_connection.c
@@ -8,7 +8,6 @@
 #include "host_connection.h"
 #include "parse_config.h"
 
-#ifdef __ZEPHYR__
 static parser_error_t parseHostConnection(config_buffer_t* buffer, host_connection_t* hostConnection) {
     hostConnection->type = ReadUInt8(buffer);
 
@@ -38,22 +37,23 @@ static parser_error_t parseHostConnection(config_buffer_t* buffer, host_connecti
 
     return ParserError_Success;
 }
-#endif
 
 parser_error_t ParseHostConnections(config_buffer_t *buffer) {
-#ifdef __ZEPHYR__
     int errorCode;
 
     for (uint8_t hostConnectionId = 0; hostConnectionId < HOST_CONNECTION_COUNT_MAX; hostConnectionId++) {
         host_connection_t dummy;
 
-        host_connection_t* hostConnection = ParserRunDry ? &dummy : &HostConnections[hostConnectionId];
+        host_connection_t* hostConnection = &dummy;
+
+#ifdef __ZEPHYR__
+        hostConnection = ParserRunDry ? &dummy : &HostConnections[hostConnectionId];
+#endif
 
         RETURN_ON_ERROR(
             parseHostConnection(buffer, hostConnection);
         );
     }
-#endif
 
     return ParserError_Success;
 }

--- a/right/src/host_connection.h
+++ b/right/src/host_connection.h
@@ -3,15 +3,28 @@
 
 // Includes:
 
-#ifdef __ZEPHYR__
-
     #include <stdint.h>
     #include <stdbool.h>
     #include "str_utils.h"
 
+#ifdef __ZEPHYR__
+
     #include <zephyr/kernel.h>
     #include <zephyr/bluetooth/bluetooth.h>
     #include <zephyr/bluetooth/addr.h>
+
+#else
+    typedef struct {
+        uint8_t val[6];
+    } bt_addr_t;
+
+    struct bt_addr_le {
+        uint8_t      type;
+        bt_addr_t    a;
+    };
+
+    typedef struct bt_addr_le bt_addr_le_t;
+#endif
 
 // Macros:
 
@@ -44,7 +57,5 @@
 // Functions:
 
     bool HostConnections_IsKnownBleAddress(const bt_addr_le_t *address);
-
-#endif
 
 #endif


### PR DESCRIPTION
Steps to reproduce:

- flash uhk60
- save 8.3.0 config (from the Agent pairing feature branch)
- observe error when the config is applied