### PR TITLE
Fix a bunch of secondary-role-related lifecycle issues.

### DIFF
--- a/right/src/event_scheduler.h
+++ b/right/src/event_scheduler.h
@@ -75,6 +75,11 @@
        EventVector_ReportsChanged =                        1 << 22,
        EventVector_NativeActionsPostponing =               1 << 23,
        EventVector_MacroEnginePostponing =                 1 << 24,
+       EventVector_MouseControllerPostponing =             1 << 25,
+
+       // helpers
+       EventVector_SomeonePostponing = EventVector_NativeActionsPostponing | EventVector_MacroEnginePostponing | EventVector_MouseControllerPostponing,
+
     } event_vector_event_t;
 
 // Variables:

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1007,7 +1007,8 @@ static macro_result_t processIfSecondaryCommand(parser_context_t* ctx, bool nega
 
     switch(res.state) {
     case SecondaryRoleState_DontKnowYet:
-        return MacroResult_Waiting;
+        // secondary role driver has its own scheduler hook to wake us up
+        return MacroResult_Sleeping;
     case SecondaryRoleState_Primary:
         if (negate) {
             goto conditionPassed;

--- a/right/src/mouse_controller.c
+++ b/right/src/mouse_controller.c
@@ -62,6 +62,7 @@ module_kinetic_state_t rightModuleKineticState = {
 usb_keyboard_reports_t MouseControllerKeyboardReports = {
     .reportsUsedVectorMask = EventVector_MouseControllerKeyboardReportsUsed,
     .recomputeStateVectorMask = EventVector_MouseController,
+    .postponeMask = EventVector_MouseControllerPostponing,
 };
 usb_mouse_report_t MouseControllerMouseReport;
 
@@ -776,5 +777,8 @@ void MouseController_ProcessMouseActions()
 
     if (keyboardReportsUsed || mouseReportsUsed || caretModeActionWasRunningSomewhere || modsChanged) {
         EventVector_Set(EventVector_ReportsChanged);
+    }
+    if (!caretModeActionIsRunningSomewhere) {
+        EventVector_Unset(EventVector_MouseControllerPostponing);
     }
 }

--- a/right/src/usb_report_updater.h
+++ b/right/src/usb_report_updater.h
@@ -26,6 +26,7 @@
         // these are metadata that should never be zeroed!
         uint32_t recomputeStateVectorMask; // mask that should be set in order to recompute them in the next update
         uint32_t reportsUsedVectorMask; // mask that indicates that these reports were used and should be merged
+        uint32_t postponeMask; // mask that indicates that these reports are initiating postponing
         // these are the working data
         usb_basic_keyboard_report_t basic;
         usb_media_keyboard_report_t media;


### PR DESCRIPTION
Closes UltimateHackingKeyboard/firmware#955 

Steps to reproduce the original issue:
- bind Shift+A in your layer (say mod)
- bind a secondary role of some other key as mod layer switch
- use the advanced resolution strategy settings with high value timeout (say 600), and trigger by release option
- now quickly press the secondary role mod switch, tap the Shift+A and then release the switch

Expected result:
- A in text editor

Actual result:
- Shift just being briefly tapped

I have tested this in both macro variant and native action variants (both are affected).

Some other related fixes:
- Eventloop no longer spins in the first phase of the native secondary role
- Time machine should now correctly respect extra modifiers of mouse-controller-bound functionality (i.e., caret mode bound to composite shortcuts, such as the shift+a
- fixed some macro sleeping issues related to both secondary role strategies

What needs testing:
- everything. This PR digs deeply into the core eventloop functionality, so bugs might pop up all over the place :-(.