### PR TITLE
Fix: dont spin eventloop on touchpad

### DIFF
--- a/right/src/slave_drivers/touchpad_driver.c
+++ b/right/src/slave_drivers/touchpad_driver.c
@@ -164,40 +164,46 @@ slave_result_t TouchpadDriver_Update(uint8_t uhkModuleDriverId)
 
             ModuleConnectionStates[UhkModuleDriverId_RightModule].lastTimeConnected = CurrentTime;
 
-            bool somethingChanged = false;
+            if (deltaX || deltaY || *(uint16_t*)&gestureEvents) {
+                bool somethingChanged = false;
 
-            if (
-                    TouchpadEvents.singleTap != gestureEvents.events0.singleTap
-                    || TouchpadEvents.twoFingerTap != gestureEvents.events1.twoFingerTap
-                    || TouchpadEvents.tapAndHold != gestureEvents.events0.tapAndHold
-                    || TouchpadEvents.noFingers != noFingers
-            ) {
-                TouchpadEvents.singleTap = gestureEvents.events0.singleTap;
-                TouchpadEvents.twoFingerTap = gestureEvents.events1.twoFingerTap;
-                TouchpadEvents.tapAndHold = gestureEvents.events0.tapAndHold;
-                TouchpadEvents.noFingers = noFingers;
-                somethingChanged = true;
-            }
+                if (
+                        TouchpadEvents.singleTap != gestureEvents.events0.singleTap
+                        || TouchpadEvents.twoFingerTap != gestureEvents.events1.twoFingerTap
+                        || TouchpadEvents.tapAndHold != gestureEvents.events0.tapAndHold
+                        || TouchpadEvents.noFingers != noFingers
+                   ) {
+                    TouchpadEvents.singleTap = gestureEvents.events0.singleTap;
+                    TouchpadEvents.twoFingerTap = gestureEvents.events1.twoFingerTap;
+                    TouchpadEvents.tapAndHold = gestureEvents.events0.tapAndHold;
+                    TouchpadEvents.noFingers = noFingers;
+                    somethingChanged = true;
+                }
 
-            if (gestureEvents.events1.scroll) {
-                TouchpadEvents.wheelX -= deltaX;
-                TouchpadEvents.wheelY += deltaY;
-                somethingChanged = true;
-            } else if (gestureEvents.events1.zoom) {
-                TouchpadEvents.zoomLevel -= deltaY;
-                somethingChanged = true;
-            } else {
-                TouchpadEvents.x -= deltaX;
-                TouchpadEvents.y += deltaY;
-                somethingChanged = true;
+                if (deltaX != 0 || deltaY != 0) {
+                    if (gestureEvents.events1.scroll) {
+                        TouchpadEvents.wheelX -= deltaX;
+                        TouchpadEvents.wheelY += deltaY;
+                        somethingChanged = true;
+                    } else if (gestureEvents.events1.zoom) {
+                        TouchpadEvents.zoomLevel -= deltaY;
+                        somethingChanged = true;
+                    } else {
+                        TouchpadEvents.x -= deltaX;
+                        TouchpadEvents.y += deltaY;
+                        somethingChanged = true;
+                    }
+                }
+
+                if (somethingChanged) {
+                    EventVector_Set(EventVector_MouseController);
+                    EventVector_WakeMain();
+                }
             }
 
             res.status = I2cAsyncWrite(address, closeCommunicationWindow, sizeof(closeCommunicationWindow));
             res.hold = false;
-            if (somethingChanged) {
-                EventVector_Set(EventVector_MouseController);
-                EventVector_WakeMain();
-            }
+
             phase = 3;
             break;
         }


### PR DESCRIPTION
Steps to reproduce:

- flash `https://github.com/UltimateHackingKeyboard/firmware-uhk80/pull/364/commits/4f34d1c15d182cdd03cb840f4b93c1b9e6527688` onto uhk v 60, (which is the UltimateHackingKeyboard/firmware-uhk80#364 branch before fix).
- connect touchpad module
- observe OUT being shown continuously
- print the status and observe something like:
```
+8 U
+7 U
+9 U
+8 U
+7 U
+8 U
+7 U
+9 U
+7 U
+7 U
+8 U
```

Steps to test the fix:

- pull and flash https://github.com/UltimateHackingKeyboard/firmware-uhk80/pull/364 (which has this branch merged in)
- connect touchpad module
- don't touch the touchpad
- observe OUT alternating with keymap name
- print the status buffer, and observe that it is no longer spammed by the above updates

Reported in https://github.com/UltimateHackingKeyboard/firmware/issues/998